### PR TITLE
Change shell command for docker containers

### DIFF
--- a/source/includes/_build.md
+++ b/source/includes/_build.md
@@ -81,15 +81,15 @@ Execute `run-iroha-dev.sh` again to attach to existing container.
 > Launching Docker and Postgres in Docker
 
 ``` shell
-docker run --name some-redis 
-    -p 6379:6379\
-    -d redis:3.2.8
+docker run --name some-redis \ 
+-p 6379:6379 \
+-d redis:3.2.8 \
 
-docker run --name some-postgres 
-    -e POSTGRES_USER=postgres \
-    -e POSTGRES_PASSWORD=mysecretpassword \
-    -p 5432:5432 \
-    -d postgres:9.5
+docker run --name some-postgres \
+-e POSTGRES_USER=postgres \
+-e POSTGRES_PASSWORD=mysecretpassword \
+-p 5432:5432 \
+-d postgres:9.5
 ```
 
 To launch Iroha daemon, running postgres and redis services are required. You may launch them on your local machine, or use docker containers, as provided on the right side.


### PR DESCRIPTION
Previously, it had bug with lack of trailing slash